### PR TITLE
Fix backend dependency conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ htmlcov/
 
 # Virtual Environment
 venv/
+\.venv/
 ENV/
 
 # Node

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ requests==2.31.0
 qiskit==0.45.0
 qiskit-aer==0.12.0
 qiskit-ibm-runtime==0.15.0
+qiskit-ibm-provider==0.7.2
 qiskit-optimization>=0.6.0
 qiskit-finance==0.4.0
 qiskit-nature==0.6.2
@@ -20,8 +21,11 @@ pydantic==2.5.2
 python-jose==3.3.0
 passlib==1.7.4
 bcrypt==4.0.1
-websockets==12.0
+websockets>=13.0
 aiohttp==3.9.0
+loguru==0.7.2
+nasdaq-data-link==1.0.4
+yfinance==0.1.70
 redis==5.0.1
 prometheus-client==0.19.0
 python-jose[cryptography]==3.3.0


### PR DESCRIPTION
## Summary
- fix back-end dependencies so Python 3.11 installs succeed
- ignore `.venv` virtual environment directories

## Testing
- `pip install -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684bb4090430832ea6ecbfbb8a92e0c0