### PR TITLE
Add optional chatbot placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,32 @@ A sophisticated quantum-powered AI assistant that leverages IBM Quantum Experien
 - Modern, responsive UI with Material-UI
 - Secure API key management
 
+## Architecture Overview
+
+The project is structured around common chatbot components:
+
+- **User Interface (UI):** React frontend located in `frontend/`.
+- **Natural Language Understanding (NLU):** Placeholder implementation in `backend/components/nlu.py`.
+- **Dialog Manager:** In-memory session tracking in `backend/components/dialog_manager.py`.
+- **Natural Language Generation (NLG):** Basic response templates in `backend/components/nlg.py`.
+- **Response Handler:** Formats replies for the UI in `backend/components/response_handler.py`.
+- **Database/Knowledge Base:** PostgreSQL used via SQLAlchemy models in `backend/models.py`.
+- **Integration Layer:** Stubs for external calls in `backend/components/integration.py`.
+- **Authentication and Authorization:** API key header handled in `backend/main.py`.
+- **Analytics and Logging:** Prometheus metrics and Loguru logging in the backend.
+- **Testing and Deployment:** Docker Compose orchestrates services; frontend uses React testing tools.
+- **Speech-to-Text / Text-to-Speech:** Placeholder implementation in `backend/components/speech.py`.
+- **Sentiment Analysis:** Basic sentiment scoring in `backend/components/sentiment.py`.
+- **Personalization:** Simple user preference storage in `backend/components/personalization.py`.
+
+## Optional Features
+
+These modules provide additional capabilities beyond the core chatbot workflow:
+
+- **Speech-to-Text / Text-to-Speech** converts between audio and text.
+- **Sentiment Analysis** evaluates user mood.
+- **Personalization** adapts replies based on user preferences.
+
 ## Prerequisites
 
 - Docker and Docker Compose

--- a/backend/components/dialog_manager.py
+++ b/backend/components/dialog_manager.py
@@ -1,0 +1,13 @@
+from typing import Dict
+
+
+class DialogManager:
+    """Minimal in-memory dialog manager."""
+
+    def __init__(self) -> None:
+        self.sessions: Dict[str, Dict[str, str]] = {}
+
+    def update_state(self, session_id: str, intent: str) -> Dict[str, str]:
+        state = self.sessions.setdefault(session_id, {})
+        state["last_intent"] = intent
+        return state

--- a/backend/components/integration.py
+++ b/backend/components/integration.py
@@ -1,0 +1,3 @@
+def call_service(name: str, payload: dict) -> dict:
+    """Placeholder for external service integrations."""
+    return {}

--- a/backend/components/nlg.py
+++ b/backend/components/nlg.py
@@ -1,0 +1,6 @@
+
+def generate_text(intent: str) -> str:
+    """Very basic NLG placeholder."""
+    if intent == "question":
+        return "I'll look into that for you."
+    return "Interesting statement."

--- a/backend/components/nlu.py
+++ b/backend/components/nlu.py
@@ -1,0 +1,8 @@
+from typing import Dict, List
+
+
+def analyze_intent_entities(text: str) -> Dict[str, List[str]]:
+    """Simple intent and entity extraction placeholder."""
+    intent = "question" if text.strip().endswith("?") else "statement"
+    entities: List[str] = []
+    return {"intent": intent, "entities": entities}

--- a/backend/components/personalization.py
+++ b/backend/components/personalization.py
@@ -1,0 +1,16 @@
+"""Personalization placeholder."""
+
+from typing import Dict
+
+
+class PersonalizationEngine:
+    """Simple user preference storage."""
+
+    def __init__(self) -> None:
+        self.preferences: Dict[str, Dict[str, str]] = {}
+
+    def get_preferences(self, user_id: str) -> Dict[str, str]:
+        return self.preferences.get(user_id, {})
+
+    def set_preferences(self, user_id: str, prefs: Dict[str, str]) -> None:
+        self.preferences[user_id] = prefs

--- a/backend/components/response_handler.py
+++ b/backend/components/response_handler.py
@@ -1,0 +1,6 @@
+from typing import Any, Dict
+
+
+def format_response(text: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Combine text with metadata for returning to the UI."""
+    return {"text": text, "metadata": metadata}

--- a/backend/components/sentiment.py
+++ b/backend/components/sentiment.py
@@ -1,0 +1,7 @@
+"""Sentiment analysis placeholder."""
+
+from typing import Dict
+
+def analyze_sentiment(text: str) -> Dict[str, float]:
+    """Return simple sentiment scores."""
+    return {"positive": 0.5, "negative": 0.5}

--- a/backend/components/speech.py
+++ b/backend/components/speech.py
@@ -1,0 +1,12 @@
+"""Speech-to-text and text-to-speech placeholders."""
+
+from typing import Any
+
+def speech_to_text(audio: bytes) -> str:
+    """Convert audio bytes to text (placeholder)."""
+    return "stub text"
+
+
+def text_to_speech(text: str) -> bytes:
+    """Convert text to audio bytes (placeholder)."""
+    return b"stub audio"


### PR DESCRIPTION
## Summary
- document optional features in README
- stub out optional modules for STT/TTS, sentiment analysis and personalization
- expose optional fields and utilities in backend

## Testing
- `python -m py_compile backend/main.py backend/components/*.py`
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f0cdfe8832ebddf76020550c9e7