### PR TITLE
Enhance docs and add summarization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # SECURITY WARNING: Never commit this file with real credentials
 API_KEY=your_secure_api_key_here
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/quantum
+
+# IBM Quantum Experience credentials
+IBM_QUANTUM_API_KEY=your_ibm_quantum_api_key_here
+IBM_QUANTUM_HUB=ibm-q
+IBM_QUANTUM_GROUP=open
+IBM_QUANTUM_PROJECT=main

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ cp .env.example .env
 
 # API Key for authentication (generate a new secure key)
 API_KEY=your_secure_api_key_here
+# IBM Quantum Experience credentials
+IBM_QUANTUM_API_KEY=your_ibm_quantum_api_key_here
+IBM_QUANTUM_HUB=ibm-q
+IBM_QUANTUM_GROUP=open
+IBM_QUANTUM_PROJECT=main
 ```
 
 4. Generate a secure API key:

--- a/backend/components/summarization.py
+++ b/backend/components/summarization.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+try:
+    from transformers import pipeline
+    summarizer = pipeline('summarization', model='sshleifer/distilbart-cnn-12-6')
+    TRANSFORMERS_AVAILABLE = True
+except Exception:
+    summarizer = None
+    TRANSFORMERS_AVAILABLE = False
+
+
+def summarize_text(text: str, max_length: int = 60, min_length: int = 10) -> str:
+    """Return a short summary of the text."""
+    if summarizer:
+        try:
+            summary = summarizer(text, max_length=max_length, min_length=min_length, do_sample=False)
+            return summary[0]['summary_text']
+        except Exception:
+            pass
+    # Fallback: truncate text
+    return ' '.join(text.split()[:max_length])

--- a/backend/main.py
+++ b/backend/main.py
@@ -62,6 +62,7 @@ from .components.response_handler import format_response
 from .components.speech import speech_to_text, text_to_speech
 from .components.sentiment import analyze_sentiment
 from .components.personalization import PersonalizationEngine
+from .components.summarization import summarize_text
 
 # Load environment variables
 load_dotenv()
@@ -149,6 +150,7 @@ class QuantumResponse(BaseModel):
     user_preferences: Optional[Dict[str, str]] = None
     nlu: Optional[Dict[str, Any]] = None
     dialog_state: Optional[Dict[str, Any]] = None
+    summary: Optional[str] = None
 
 # Initialize quantum services with advanced error handling
 try:
@@ -332,6 +334,7 @@ async def generate_quantum_response(message: str) -> QuantumResponse:
         # Generate response using quantum-enhanced NLP and simple NLG
         base_text = generate_response_from_quantum_state(quantum_state, nlg_text)
         formatted = format_response(base_text, {"nlu": nlu, "state": dialog_state})
+        summary = summarize_text(formatted["text"]) if formatted.get("text") else None
         
         # Calculate processing time
         processing_time = (datetime.now() - start_time).total_seconds()
@@ -351,7 +354,8 @@ async def generate_quantum_response(message: str) -> QuantumResponse:
             sentiment=sentiment,
             user_preferences=user_prefs,
             nlu=nlu,
-            dialog_state=dialog_state
+            dialog_state=dialog_state,
+            summary=summary
         )
     
     except Exception as e:
@@ -418,7 +422,8 @@ async def root():
             "Advanced emotion analysis",
             "Language detection",
             "Quantum metrics analysis",
-            "Next best action prediction"
+            "Next best action prediction",
+            "Automatic summarization"
         ]
     }
 

--- a/backend/tests/test_summarization.py
+++ b/backend/tests/test_summarization.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from components.summarization import summarize_text
+
+def test_summarize_text():
+    text = "This is a very long text that should be summarized into a shorter form. " * 5
+    summary = summarize_text(text)
+    assert isinstance(summary, str)
+    assert len(summary) > 0


### PR DESCRIPTION
## Summary
- document IBM Quantum credentials in example env file and README
- add summarization component using Hugging Face transformers
- include summary in `QuantumResponse`
- list summarization in API root features
- test summarization helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc4632408832e823712465bf262e8